### PR TITLE
Set dotnet install directory

### DIFF
--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -53,6 +53,7 @@ jobs:
         working-directory: windows
 
       - name: Push Docker image
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker push ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:${{ matrix.tag }}
         working-directory: windows
@@ -63,6 +64,7 @@ jobs:
         working-directory: windows
 
       - name: Push Xamarin Docker image
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker push ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:${{ matrix.tag }}-xamarin
         working-directory: windows

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -33,9 +33,9 @@ RUN `
 # Install supported .NET SDKs
 RUN `
     curl -fSLO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1 `
-    && powershell .\dotnet-install.ps1 -Channel 6.0 `
-    && powershell .\dotnet-install.ps1 -Channel 7.0 `
-    && powershell .\dotnet-install.ps1 -Channel 8.0 `
+    && powershell .\dotnet-install.ps1 -Channel 6.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
+    && powershell .\dotnet-install.ps1 -Channel 7.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
+    && powershell .\dotnet-install.ps1 -Channel 8.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
     && del dotnet-install.ps1
 
 WORKDIR /actions-runner


### PR DESCRIPTION
`actions/setup-dotnet` was downloading and installing .NET SDKs that were already installed. `dotnet --list-sdks` was not showing the versions installed by `dotnet-install.ps1` because they were installed in a user-local path, but `dotnet` run from `C:\Program Files\dotnet` doesn't check there.