### PR TITLE
Support "Enterprise" runners in Windows dockerfile.

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -65,4 +65,4 @@ RUN powershell choco feature enable -n allowGlobalConfirmation
 
 RUN powershell choco install azure-cli  --no-progress -y
 
-CMD [ "pwsh", "-c", "./config.cmd --name $env:RUNNER_NAME --url $env:GITHUB_URL$env:RUNNER_ORG --token $env:RUNNER_TOKEN --labels $env:RUNNER_LABELS --unattended --replace --ephemeral; ./run.cmd"]
+CMD [ "pwsh", "-c", "./config.cmd --name $env:RUNNER_NAME --url $env:GITHUB_URL$($env:RUNNER_ENTERPRISE ? 'enterprises/' + $env:RUNNER_ENTERPRISE : $env:RUNNER_ORG) --token $env:RUNNER_TOKEN --labels $env:RUNNER_LABELS --unattended --replace --ephemeral; ./run.cmd"]


### PR DESCRIPTION
The `RUNNER_ENTERPRISE` environment-variable is set when creating an enterprise-wide runner. DEVEN-4445

Logic adapted from https://github.com/actions/actions-runner-controller/blob/e06c7edc213b098729e49343b4c085615bf46671/runner/startup.sh#L35-L46