### PR TITLE
Add Windows VS2026 runner image

### DIFF
--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -15,16 +15,18 @@ env:
 
 jobs:
   build-windows:
-    runs-on: [windows-2022]
     strategy:
       matrix:
         image:
           - tag: ltsc2022
+            runner: windows-2022
             dockerfile: Dockerfile
             base: 4.8.1-20251014-windowsservercore-ltsc2022
           - tag: vs2026
+            runner: windows-2025
             dockerfile: vs2026.Dockerfile
             base: 4.8.1-20251014-windowsservercore-ltsc2025
+    runs-on: ${{ matrix.image.runner }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -16,6 +16,15 @@ env:
 jobs:
   build-windows:
     runs-on: [windows-2022]
+    strategy:
+      matrix:
+        image:
+          - tag: ltsc2022
+            dockerfile: Dockerfile
+            base: 4.8.1-20251014-windowsservercore-ltsc2022
+          - tag: vs2026
+            dockerfile: vs2026.Dockerfile
+            base: 4.8.1-20251014-windowsservercore-ltsc2025
     permissions:
       contents: read
       packages: write
@@ -40,11 +49,11 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build . --pull --tag ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:ltsc2022 --build-arg BASE=4.8.1-20251014-windowsservercore-ltsc2022 --build-arg ARIAL_TTF_URL=${{ secrets.ARIAL_TTF_URL }}
+          docker build . --pull --file ${{ matrix.image.dockerfile }} --tag ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:${{ matrix.image.tag }} --build-arg BASE=${{ matrix.image.base }} --build-arg ARIAL_TTF_URL=${{ secrets.ARIAL_TTF_URL }}
         working-directory: windows
 
       - name: Push Docker image
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          docker push ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:ltsc2022
+          docker push ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:${{ matrix.image.tag }}
         working-directory: windows

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -22,10 +22,11 @@ jobs:
             runner: windows-2022
             dockerfile: Dockerfile
             base: 4.8.1-windowsservercore-ltsc2022
-          - tag: vs2026
-            runner: windows-2025
-            dockerfile: vs2026.Dockerfile
-            base: 4.8.1-windowsservercore-ltsc2025
+          # Temporarily disabled due to GitHub-hosted runner disk limits.
+          # - tag: vs2026
+          #   runner: windows-2025
+          #   dockerfile: vs2026.Dockerfile
+          #   base: 4.8.1-windowsservercore-ltsc2025
     runs-on: ${{ matrix.image.runner }}
     permissions:
       contents: read

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -21,11 +21,11 @@ jobs:
           - tag: ltsc2022
             runner: windows-2022
             dockerfile: Dockerfile
-            base: 4.8.1-20251014-windowsservercore-ltsc2022
+            base: 4.8.1-windowsservercore-ltsc2022
           - tag: vs2026
             runner: windows-2025
             dockerfile: vs2026.Dockerfile
-            base: 4.8.1-20251014-windowsservercore-ltsc2025
+            base: 4.8.1-windowsservercore-ltsc2025
     runs-on: ${{ matrix.image.runner }}
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ This image is based on `ghcr.io/actions/actions-runner:latest` (which installs t
 
 ### Windows
 
-The Windows images require a font to be installed.
-`ARIAL_TTF_URL` can be constructed by opening asset 15079750 in Amber and getting a CDN URL.
-It's also stored as a repository secret.
-
 #### Tags: `ltsc2022`
 
 The Windows Dockerfile was derived from the [instructions](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/docs/detailed-docs.md#setting-up-windows-runners) and the example in [this PR](https://github.com/isarkis/actions-runner-controller/pull/1/files).
@@ -48,3 +44,27 @@ The `windows/vs2026.Dockerfile` image starts from the .NET Framework 4.8.1 LTSC 
 * [Git for Windows](https://community.chocolatey.org/packages/git.install)
 * [.NET 8 SDK, .NET 9 SDK, .NET 10 SDK](https://dotnet.microsoft.com/)
 * [Visual C++ Tools](https://learn.microsoft.com/visualstudio/install/workload-component-id-vs-build-tools?view=visualstudio#desktop-development-with-c++)
+
+#### Building Locally
+
+To build the Windows images locally, install Docker Desktop and switch it to Windows containers.
+
+The Windows images require a font to be installed.
+`ARIAL_TTF_URL` can be constructed by opening asset 15079750 in Amber and getting a CDN URL.
+It's also stored as a repository secret.
+
+Then run:
+
+```powershell
+cd actions-runner-image\windows
+$env:DOCKER_BUILDKIT = '0'
+tar.exe -cf context.tar Dockerfile vs2026.Dockerfile yes.txt android-sdk-license
+Get-Content .\context.tar -AsByteStream | docker build --pull -t actions-runner-image:vs2026 -f vs2026.Dockerfile --build-arg BASE=4.8.1-windowsservercore-ltsc2025 --build-arg "ARIAL_TTF_URL=https://SECRET_VALUE_HERE" -
+del .\context.tar
+```
+
+The steps above avoid the following error that may occur when just running `docker build`:
+
+```
+unable to prepare context: unable to evaluate symlinks in context path: EvalSymlinks: too many links
+```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ This image is based on `ghcr.io/actions/actions-runner:latest` (which installs t
 
 ### Windows
 
+The Windows images require a font to be installed.
+`ARIAL_TTF_URL` can be constructed by opening asset 15079750 in Amber and getting a CDN URL.
+It's also stored as a repository secret.
+
 #### Tags: `ltsc2022`
 
 The Windows Dockerfile was derived from the [instructions](https://github.com/actions-runner-controller/actions-runner-controller/blob/master/docs/detailed-docs.md#setting-up-windows-runners) and the example in [this PR](https://github.com/isarkis/actions-runner-controller/pull/1/files).
@@ -33,3 +37,14 @@ It is based on the `mcr.microsoft.com/dotnet/framework/sdk` image. It adds:
 * [Azure CLI](https://community.chocolatey.org/packages/azure-cli)
 * [Git for Windows](https://community.chocolatey.org/packages/git.install)
 * [Visual C++ Tools](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022#desktop-development-with-c)
+
+#### Tags: `vs2026`
+
+The `windows/vs2026.Dockerfile` image starts from the .NET Framework 4.8.1 LTSC 2025 runtime image, installs the Visual Studio 2026 / VS18 SDK stack, and adds Desktop development with C++. It also adds the same runner/tooling stack as the standard Windows image:
+
+* [GitHub Actions Runner](https://github.com/actions/runner)
+* [PowerShell](https://learn.microsoft.com/powershell/)
+* [Azure CLI](https://community.chocolatey.org/packages/azure-cli)
+* [Git for Windows](https://community.chocolatey.org/packages/git.install)
+* [.NET 8 SDK, .NET 9 SDK, .NET 10 SDK](https://dotnet.microsoft.com/)
+* [Visual C++ Tools](https://learn.microsoft.com/visualstudio/install/workload-component-id-vs-build-tools?view=visualstudio#desktop-development-with-c++)

--- a/windows/vs2026.Dockerfile
+++ b/windows/vs2026.Dockerfile
@@ -25,9 +25,6 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
-    # ngen assemblies queued by VS installers
-    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `

--- a/windows/vs2026.Dockerfile
+++ b/windows/vs2026.Dockerfile
@@ -1,56 +1,29 @@
 # escape=`
 
-ARG BASE=4.8.1-20251014-windowsservercore-ltsc2025
-FROM mcr.microsoft.com/dotnet/framework/runtime:${BASE}
+ARG BASE
+FROM mcr.microsoft.com/dotnet/framework/sdk:${BASE}
 
 # latest values from https://github.com/actions/runner/releases for actions-runner-win-x64-N.N.N.zip
 ARG RUNNER_VERSION=2.333.0
 ARG RUNNER_DOWNLOAD_HASH=7176d0c4b674d4108b515503a53b4bc9eeab9339c645e274a97c142fe1c64b95
 
-ENV `
-    # Do not generate certificate
-    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
-    # Enable correct mode for dotnet watch (only mode supported in a container)
-    DOTNET_USE_POLLING_FILE_WATCHER=true `
-    # NuGet version to install
-    NUGET_VERSION=7.3.0 `
-    # Install location of Roslyn
-    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\Roslyn"
-
+# VS commands adapted from https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8.1/windowsservercore-ltsc2025/Dockerfile
 SHELL [ "cmd.exe", "/S", "/C" ]
 
-# Install NuGet CLI
-RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
-
-# Install the VS18 SDK stack, then add Desktop development with C++.
-RUN curl -fSLo vs_BuildTools.exe https://aka.ms/vs/stable/vs_BuildTools.exe `
-    && start /w vs_BuildTools ^ `
+# Modify VS to add Desktop development with C++
+# https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=visualstudio#desktop-development-with-c
+RUN `
+  curl -fSLo vs_BuildTools.exe https://aka.ms/vs/18/stable/vs_BuildTools.exe `
+    && start /w vs_BuildTools modify ^ `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\18\BuildTools" ^ `
-        --add Microsoft.Component.ClickOnce.MSBuild ^ `
-        --add Microsoft.Net.Component.4.8.1.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.10.0 ^ `
-        --add Microsoft.NetCore.Component.SDK ^ `
-        --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
-        --add Microsoft.VisualStudio.Component.TestTools.BuildTools ^ `
-        --add Microsoft.VisualStudio.Component.VC.ATL ^ `
-        --add Microsoft.VisualStudio.Component.WebDeploy ^ `
-        --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup ^ `
-        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
         --add Microsoft.VisualStudio.Workload.VCTools ^ `
+        --add Microsoft.VisualStudio.Component.VC.ATL ^ `
+        --add Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64 ^ `
+        --add Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL ^ `
+        --add Microsoft.VisualStudio.Component.Windows10SDK ^ `
         --quiet --includeRecommended --norestart --nocache --wait `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
-    `
-    # Trigger dotnet first run experience by running arbitrary cmd
-    && "%ProgramFiles%\dotnet\dotnet" help `
-    `
-    # Workaround for issues with 64-bit ngen
-    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\SecAnnotate.exe" `
-    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
@@ -59,29 +32,6 @@ RUN curl -fSLo vs_BuildTools.exe https://aka.ms/vs/stable/vs_BuildTools.exe `
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*"
-
-# Set PATH in one layer to keep image size down.
-RUN powershell setx /M PATH $(${Env:PATH} `
-    + \";${Env:ProgramFiles}\NuGet\" `
-    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\amd64\" `
-    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\18\BuildTools\Common7\IDE\Extensions\TestPlatform\" `
-    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\" `
-    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
-
-# Install Targeting Packs
-RUN powershell -Command "`
-    $referenceAssembliesPath = \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\"; `
-    New-Item -ItemType Directory -Path ${referenceAssembliesPath}; `
-    foreach ($version in @('net40', 'net45', 'net451', 'net452', 'net46', 'net461', 'net462', 'net47', 'net471', 'net472', 'net48', 'net481')) { `
-        $package = \"Microsoft.NETFramework.ReferenceAssemblies.${version}\"; `
-        nuget install \"${package}\" -DirectDownload -ExcludeVersion -Version 1.0.3 -OutputDirectory ${Env:TEMP}\Packages -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json; `
-        $contents = \"${Env:TEMP}\Packages\${package}\build\.NETFramework\"; `
-        Get-ChildItem -File -Recurse -Path \"${contents}\" | `
-            Where-Object { $_.FullName -match '^(?!.*(PermissionSets|RedistList)).*\.xml$' } | `
-            Remove-Item; `
-        Copy-Item -Recurse -Force -Container -Path ${contents} -Destination ${referenceAssembliesPath}; `
-    } `
-    Remove-Item -Force -Recurse ${Env:TEMP}\\*;"
 
 # Install supported .NET SDKs
 RUN `

--- a/windows/vs2026.Dockerfile
+++ b/windows/vs2026.Dockerfile
@@ -1,0 +1,122 @@
+# escape=`
+
+ARG BASE=4.8.1-20251014-windowsservercore-ltsc2025
+FROM mcr.microsoft.com/dotnet/framework/runtime:${BASE}
+
+# latest values from https://github.com/actions/runner/releases for actions-runner-win-x64-N.N.N.zip
+ARG RUNNER_VERSION=2.333.0
+ARG RUNNER_DOWNLOAD_HASH=7176d0c4b674d4108b515503a53b4bc9eeab9339c645e274a97c142fe1c64b95
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # NuGet version to install
+    NUGET_VERSION=7.3.0 `
+    # Install location of Roslyn
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\Roslyn"
+
+SHELL [ "cmd.exe", "/S", "/C" ]
+
+# Install NuGet CLI
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
+
+# Install the VS18 SDK stack, then add Desktop development with C++.
+RUN curl -fSLo vs_BuildTools.exe https://aka.ms/vs/stable/vs_BuildTools.exe `
+    && start /w vs_BuildTools ^ `
+        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\18\BuildTools" ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --add Microsoft.Net.Component.4.8.1.SDK ^ `
+        --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.10.0 ^ `
+        --add Microsoft.NetCore.Component.SDK ^ `
+        --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
+        --add Microsoft.VisualStudio.Component.TestTools.BuildTools ^ `
+        --add Microsoft.VisualStudio.Component.VC.ATL ^ `
+        --add Microsoft.VisualStudio.Component.WebDeploy ^ `
+        --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.VCTools ^ `
+        --quiet --includeRecommended --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_BuildTools.exe `
+    `
+    # Trigger dotnet first run experience by running arbitrary cmd
+    && "%ProgramFiles%\dotnet\dotnet" help `
+    `
+    # Workaround for issues with 64-bit ngen
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\SecAnnotate.exe" `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
+    # Cleanup
+    && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
+    && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*"
+
+# Set PATH in one layer to keep image size down.
+RUN powershell setx /M PATH $(${Env:PATH} `
+    + \";${Env:ProgramFiles}\NuGet\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\amd64\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\18\BuildTools\Common7\IDE\Extensions\TestPlatform\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
+
+# Install Targeting Packs
+RUN powershell -Command "`
+    $referenceAssembliesPath = \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\"; `
+    New-Item -ItemType Directory -Path ${referenceAssembliesPath}; `
+    foreach ($version in @('net40', 'net45', 'net451', 'net452', 'net46', 'net461', 'net462', 'net47', 'net471', 'net472', 'net48', 'net481')) { `
+        $package = \"Microsoft.NETFramework.ReferenceAssemblies.${version}\"; `
+        nuget install \"${package}\" -DirectDownload -ExcludeVersion -Version 1.0.3 -OutputDirectory ${Env:TEMP}\Packages -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json; `
+        $contents = \"${Env:TEMP}\Packages\${package}\build\.NETFramework\"; `
+        Get-ChildItem -File -Recurse -Path \"${contents}\" | `
+            Where-Object { $_.FullName -match '^(?!.*(PermissionSets|RedistList)).*\.xml$' } | `
+            Remove-Item; `
+        Copy-Item -Recurse -Force -Container -Path ${contents} -Destination ${referenceAssembliesPath}; `
+    } `
+    Remove-Item -Force -Recurse ${Env:TEMP}\\*;"
+
+# Install supported .NET SDKs
+RUN `
+    curl -fSLO https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1 `
+    && powershell .\dotnet-install.ps1 -Channel 8.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
+    && powershell .\dotnet-install.ps1 -Channel 9.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
+    && powershell .\dotnet-install.ps1 -Channel 10.0 -InstallDir "\"C:\Program Files\dotnet\\"" `
+    && del dotnet-install.ps1
+
+WORKDIR /actions-runner
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';$ProgressPreference='silentlyContinue';"]
+
+# install a font as per https://techcommunity.microsoft.com/t5/itops-talk-blog/adding-optional-font-packages-to-windows-containers/bc-p/3561988#messageview_0
+ARG ARIAL_TTF_URL
+RUN Invoke-WebRequest -Uri "$env:ARIAL_TTF_URL" -OutFile arial.ttf; `
+   copy-item arial.ttf c:\windows\fonts\; `
+   Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts' -name 'Arial' -value 'arial.ttf' -type STRING; `
+   Remove-Item arial.ttf;
+
+RUN Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v$env:RUNNER_VERSION/actions-runner-win-x64-$env:RUNNER_VERSION.zip" -OutFile "actions-runner-win-x64-$env:RUNNER_VERSION.zip"
+
+RUN if((Get-FileHash -Path actions-runner-win-x64-$env:RUNNER_VERSION.zip -Algorithm SHA256).Hash.ToUpper() -ne $env:RUNNER_DOWNLOAD_HASH){ throw 'Computed checksum did not match' }
+
+RUN Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory(""""actions-runner-win-x64-$env:RUNNER_VERSION.zip"""", $PWD)
+
+RUN Invoke-WebRequest -Uri 'https://aka.ms/install-powershell.ps1' -OutFile install-powershell.ps1; ./install-powershell.ps1 -AddToPath
+
+RUN powershell Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+RUN powershell choco install git.install --no-progress --params "'/GitAndUnixToolsOnPath'" -y
+
+RUN powershell choco feature enable -n allowGlobalConfirmation
+
+RUN powershell choco install azure-cli --no-progress -y
+
+# Disable dynamic port UDP/65330; Azure DNS resolution can fail once every 16,383 attempts using the default `NetUDPSetting`s.
+CMD [ "pwsh", "-c", "netsh int ipv4 add excludedportrange udp 65330 1 persistent; ./config.cmd --name $env:RUNNER_NAME --url $env:GITHUB_URL$($env:RUNNER_ENTERPRISE ? 'enterprises/' + $env:RUNNER_ENTERPRISE : $env:RUNNER_ORG) --token $env:RUNNER_TOKEN --labels $env:RUNNER_LABELS --unattended --replace --ephemeral; ./run.cmd"]


### PR DESCRIPTION
## Summary

- add `windows/vs2026.Dockerfile` for a dedicated Visual Studio 2026 / VS18 Windows runner image on LTSC 2025
- publish the new `vs2026` image tag alongside the existing `ltsc2022` image in the Windows workflow
- run each Windows image on a compatible hosted runner (`windows-2022` for `ltsc2022`, `windows-2025` for `vs2026`)
- document the new image and Windows font requirement in `README.md`

## Testing

- `docker build -f windows/vs2026.Dockerfile ...`
- `docker run --rm --entrypoint powershell actions-runner-image:vs2026-test -Command '& ''C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'' -products * -property installationPath; & ''C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe'' -version; & ''C:\Program Files\dotnet\dotnet.exe'' --list-sdks; & ''C:\Program Files\Git\cmd\git.exe'' --version'`
- `docker run --rm --entrypoint powershell actions-runner-image:vs2026-test -Command 'pwsh -NoLogo -NoProfile -Command ''$PSVersionTable.PSVersion.ToString()'''`
