### PR TITLE
Install Android SDK for dotnet Android workloads.

### DIFF
--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -50,8 +50,11 @@ jobs:
         with:
           string: ${{ github.repository }}
 
-      - name: Switch to Windows containers
-        run: '& "$Env:ProgramFiles\Docker\Docker\DockerCli.exe" -SwitchWindowsEngine'
+      - name: Start Docker service
+        run: |
+          Start-Service docker
+          Start-Sleep -Seconds 10
+          docker info
         shell: pwsh
 
       - name: Build Docker image

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           string: ${{ github.repository }}
 
+      - name: Switch to Windows containers
+        run: '& "$Env:ProgramFiles\Docker\Docker\DockerCli.exe" -SwitchWindowsEngine'
+        shell: pwsh
+
       - name: Build Docker image
         run: |
           docker build . --pull --file ${{ matrix.image.dockerfile }} --tag ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}:${{ matrix.image.tag }} --build-arg BASE=${{ matrix.image.base }} --build-arg ARIAL_TTF_URL=${{ secrets.ARIAL_TTF_URL }}

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -65,5 +65,22 @@ RUN powershell choco feature enable -n allowGlobalConfirmation
 
 RUN powershell choco install azure-cli  --no-progress -y
 
+# Install Java 17 (required by Android SDK command-line tools)
+RUN powershell choco install microsoft-openjdk17 --no-progress -y
+
+# Install Android SDK
+# https://developer.android.com/tools (commandlinetools-win-*.zip)
+ARG ANDROID_SDK_CMDLINE_TOOLS_VERSION=11076708
+ENV ANDROID_HOME=C:\android-sdk
+ENV ANDROID_SDK_ROOT=C:\android-sdk
+ENV PATH="${PATH};C:\android-sdk\cmdline-tools\latest\bin;C:\android-sdk\platform-tools"
+RUN New-Item -ItemType Directory -Path $env:ANDROID_HOME | Out-Null; `
+    Invoke-WebRequest -Uri "https://dl.google.com/android/repository/commandlinetools-win-${env:ANDROID_SDK_CMDLINE_TOOLS_VERSION}_latest.zip" -OutFile cmdline-tools.zip; `
+    Expand-Archive cmdline-tools.zip -DestinationPath "$env:ANDROID_HOME\cmdline-tools"; `
+    Rename-Item "$env:ANDROID_HOME\cmdline-tools\cmdline-tools" "$env:ANDROID_HOME\cmdline-tools\latest"; `
+    Remove-Item cmdline-tools.zip; `
+    (1..10 | ForEach-Object { "yes" }) -join "`n" | & "$env:ANDROID_HOME\cmdline-tools\latest\bin\sdkmanager.bat" --sdk_root="$env:ANDROID_HOME" --licenses; `
+    & "$env:ANDROID_HOME\cmdline-tools\latest\bin\sdkmanager.bat" --sdk_root="$env:ANDROID_HOME" "platform-tools" "build-tools;36.0.0" "platforms;android-36"
+
 # Disable dynamic port UDP/65330; Azure DNS resolution can fail once every 16,383 attempts using the default `NetUDPSetting`s.
 CMD [ "pwsh", "-c", "netsh int ipv4 add excludedportrange udp 65330 1 persistent; ./config.cmd --name $env:RUNNER_NAME --url $env:GITHUB_URL$($env:RUNNER_ENTERPRISE ? 'enterprises/' + $env:RUNNER_ENTERPRISE : $env:RUNNER_ORG) --token $env:RUNNER_TOKEN --labels $env:RUNNER_LABELS --unattended --replace --ephemeral; ./run.cmd"]


### PR DESCRIPTION
Currently, a `dotnet workload restore` which includes the Android workload then results in:
```
  Error: C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.53\tools\Xamarin.Android.Tooling.targets(58,5): error XA5300: The Android SDK directory could not be found. Install the Android SDK by following the instructions at: https://aka.ms/dotnet-android-install-sdk [C:\actions-runner\_work\ReadingPlanServices\ReadingPlanServices\src\Logos.Documents.ReadingPlans.V4.Client\Logos.Documents.ReadingPlans.V4.Client.csproj::TargetFramework=net10.0-android]
  Error: C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\36.1.53\tools\Xamarin.Android.Tooling.targets(58,5): error XA5300: To use a custom SDK path for a command line build, set the 'AndroidSdkDirectory' MSBuild property to the custom path. [C:\actions-runner\_work\ReadingPlanServices\ReadingPlanServices\src\Logos.Documents.ReadingPlans.V4.Client\Logos.Documents.ReadingPlans.V4.Client.csproj::TargetFramework=net10.0-android]
  ```
  
These are presumably [preinstalled on GitHub](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md#android) `windows-latest` runners (which is why non-logos runners can build these workloads.

An alternative solution would be per-run, something like:
```
    - name: Set up JDK 17
      uses: actions/setup-java@v4
      with:
        distribution: 'zulu'
        java-version: '17'

    - name: Setup Android SDK
      uses: android-actions/setup-android@v3
      with:
        accept-android-sdk-licenses: 'yes' 
```