### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/docker-publish-linux.yml
+++ b/.github/workflows/docker-publish-linux.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -46,13 +46,13 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -70,7 +70,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: linux
           file: linux/summerwind.Dockerfile
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -116,13 +116,13 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -132,7 +132,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -142,7 +142,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: linux
           file: linux/actions.Dockerfile

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -46,9 +46,9 @@ jobs:
 
       - id: image_name
         name: Make image name lowercase
-        uses: ASzc/change-string-case-action@v7
-        with:
-          string: ${{ github.repository }}
+        run: |
+          $imageName = '${{ github.repository }}'.ToLowerInvariant()
+          "lowercase=$imageName" >> $env:GITHUB_OUTPUT
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/docker-publish-windows.yml
+++ b/.github/workflows/docker-publish-windows.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
 
       - id: image_name
         name: Make image name lowercase
-        uses: ASzc/change-string-case-action@v6
+        uses: ASzc/change-string-case-action@v7
         with:
           string: ${{ github.repository }}
 


### PR DESCRIPTION
Updates workflow action majors that target deprecated Node.js 20 runtime to Node.js 24-compatible releases.\n\n- actions/checkout: v4 -> v5\n- docker/login-action: v3 -> v4\n- ASzc/change-string-case-action: v6 -> v7\n- docker/setup-buildx-action: v3 -> v4\n- docker/metadata-action: v5 -> v6\n- docker/build-push-action: v5 -> v7